### PR TITLE
ASP.NET Observer abstractions

### DIFF
--- a/src/Metrics.AspNet/AspNetObserver.cs
+++ b/src/Metrics.AspNet/AspNetObserver.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using O9d.Observability;
+
+namespace O9d.Metrics.AspNet
+{
+    public abstract class AspNetObserver : IObserver<KeyValuePair<string, object?>>
+    {        
+        private readonly PropertyFetcher<Exception> _exceptionFetcher = new("exception");
+        private readonly PropertyFetcher<HttpContext> _exceptionContextFetcher = new("httpContext");
+        
+        public virtual void OnHttpRequestStarted(HttpContext httpContext)
+        {
+        }
+
+        public virtual void OnEndpointMatched(HttpContext httpContext)
+        {
+        }
+
+        public virtual void OnUnhandledException(HttpContext httpContext, Exception exception)
+        {
+        }
+
+        public virtual void OnHttpRequestCompleted(HttpContext httpContext)
+        {
+        }
+
+        void IObserver<KeyValuePair<string, object?>>.OnNext(KeyValuePair<string, object?> kvp)
+        {
+            if (kvp.Value is null)
+                return; // log?
+            
+            switch (kvp.Key)
+            {
+                case "Microsoft.AspNetCore.Hosting.HttpRequestIn.Start":
+                    OnHttpRequestStarted((HttpContext)kvp.Value);
+                    break;
+                case "Microsoft.AspNetCore.Routing.EndpointMatched":
+                    OnEndpointMatched((HttpContext)kvp.Value);
+                    break;
+                // Ref https://github.com/dotnet/aspnetcore/blob/52eff90fbcfca39b7eb58baad597df6a99a542b0/src/Middleware/Diagnostics/test/UnitTests/TestDiagnosticListener.cs
+                case "Microsoft.AspNetCore.Diagnostics.UnhandledException":
+                    ProcessException(kvp);
+                    break;
+                case "Microsoft.AspNetCore.Hosting.HttpRequestIn.Stop":
+                    OnHttpRequestCompleted((HttpContext)kvp.Value);
+                    break;
+            }
+        }
+
+        void IObserver<KeyValuePair<string, object?>>.OnCompleted()
+        {
+            // Not used
+        }
+
+        void IObserver<KeyValuePair<string, object?>>.OnError(Exception error)
+        {
+            // Not used
+        }
+
+        private void ProcessException(KeyValuePair<string, object?> kvp)
+        {
+            if (kvp.Value is not null 
+                && _exceptionFetcher.TryFetch(kvp.Value, out Exception? ex)
+                && ex is {}
+                && _exceptionContextFetcher.TryFetch(kvp.Value, out HttpContext? httpContext)
+                && httpContext is {}
+            )
+            {
+                OnUnhandledException(httpContext, ex);
+            }
+        }        
+    }
+}

--- a/src/Metrics.AspNet/AspNetObserver.cs
+++ b/src/Metrics.AspNet/AspNetObserver.cs
@@ -26,25 +26,25 @@ namespace O9d.Metrics.AspNet
         {
         }
 
-        void IObserver<KeyValuePair<string, object?>>.OnNext(KeyValuePair<string, object?> kvp)
+        void IObserver<KeyValuePair<string, object?>>.OnNext(KeyValuePair<string, object?> value)
         {
-            if (kvp.Value is null)
+            if (value.Value is null)
                 return; // log?
             
-            switch (kvp.Key)
+            switch (value.Key)
             {
                 case "Microsoft.AspNetCore.Hosting.HttpRequestIn.Start":
-                    OnHttpRequestStarted((HttpContext)kvp.Value);
+                    OnHttpRequestStarted((HttpContext)value.Value);
                     break;
                 case "Microsoft.AspNetCore.Routing.EndpointMatched":
-                    OnEndpointMatched((HttpContext)kvp.Value);
+                    OnEndpointMatched((HttpContext)value.Value);
                     break;
                 // Ref https://github.com/dotnet/aspnetcore/blob/52eff90fbcfca39b7eb58baad597df6a99a542b0/src/Middleware/Diagnostics/test/UnitTests/TestDiagnosticListener.cs
                 case "Microsoft.AspNetCore.Diagnostics.UnhandledException":
-                    ProcessException(kvp);
+                    ProcessException(value);
                     break;
                 case "Microsoft.AspNetCore.Hosting.HttpRequestIn.Stop":
-                    OnHttpRequestCompleted((HttpContext)kvp.Value);
+                    OnHttpRequestCompleted((HttpContext)value.Value);
                     break;
             }
         }

--- a/test/Metrics.AspNet.Tests/AspNetObserverTests.cs
+++ b/test/Metrics.AspNet.Tests/AspNetObserverTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using Shouldly;
+using Xunit;
+
+namespace O9d.Metrics.AspNet.Tests
+{
+    public class AspNetObserverTests
+    {
+        private readonly TestObserver _observer;
+        private readonly DefaultHttpContext _httpContext;
+
+        public AspNetObserverTests()
+        {
+            _observer = new TestObserver();
+            _httpContext = new DefaultHttpContext();
+        }
+
+        [Fact]
+        public void Handles_unhandled_exception_events()
+        {
+            var ex = new Exception();
+
+            var @event = new
+            {
+                httpContext = _httpContext,
+                exception = ex
+            };
+
+            _observer.HandleEvent("Microsoft.AspNetCore.Diagnostics.UnhandledException", @event);
+
+            _observer.OnUnhandledExceptionInvoked.ShouldBeTrue();
+            _observer.UnhandledException.ShouldBe(ex);
+            _observer.HttpContext.ShouldBe(_httpContext);
+        }
+
+        [Fact]
+        public void Skips_invalid_exception_events()
+        {
+            // Invalid event schema
+            var @event = new
+            {
+                context = _httpContext,
+                ex = new Exception()
+            };
+
+            _observer.HandleEvent("Microsoft.AspNetCore.Diagnostics.UnhandledException", @event);
+
+            _observer.OnUnhandledExceptionInvoked.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Skips_valid_exception_events_with_null_fields()
+        {
+            // Invalid event schema
+            var @event = new
+            {
+                context = default(HttpContext),
+                ex = default(Exception)
+            };
+
+            _observer.HandleEvent("Microsoft.AspNetCore.Diagnostics.UnhandledException", @event);
+
+            _observer.OnUnhandledExceptionInvoked.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Handles_request_start_events()
+        {
+            _observer.HandleEvent("Microsoft.AspNetCore.Hosting.HttpRequestIn.Start", _httpContext);
+            _observer.HttpContext.ShouldNotBeNull();   
+        }
+
+        [Fact]
+        public void Handles_endpoint_matched_events()
+        {
+            _observer.HandleEvent("Microsoft.AspNetCore.Routing.EndpointMatched", _httpContext);
+            _observer.HttpContext.ShouldNotBeNull();   
+        }
+
+        [Fact]
+        public void Handles_request_stop_events()
+        {
+            _observer.HandleEvent("Microsoft.AspNetCore.Hosting.HttpRequestIn.Stop", _httpContext);
+            _observer.HttpContext.ShouldNotBeNull();   
+        }
+
+        private class TestObserver : AspNetObserver
+        {
+            public HttpContext? HttpContext { get; private set; }
+            public Exception? UnhandledException { get; private set; }
+            public bool OnUnhandledExceptionInvoked { get; private set; }
+
+            public override void OnUnhandledException(HttpContext httpContext, Exception exception)
+            {
+                HttpContext = httpContext;
+                UnhandledException = exception;
+                OnUnhandledExceptionInvoked = true;
+            }
+
+            public override void OnHttpRequestStarted(HttpContext httpContext)
+            {
+                HttpContext = httpContext;
+            }
+
+            public override void OnEndpointMatched(HttpContext httpContext)
+            {
+                HttpContext = httpContext;
+            }
+
+            public override void OnHttpRequestCompleted(HttpContext httpContext)
+            {
+                HttpContext = httpContext;
+            }
+
+            public void HandleEvent(string key, object @event)
+            {
+                ((IObserver<KeyValuePair<string, object?>>)this)
+                    .OnNext(new(key, @event));
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds an abstraction to make it easier to build observers for ASP.NET events without having to understand the event names and schemas. We could potentially split up the existing metrics observer but I would prefer to run some benchmarks first to see the impact of having multiple observers vs one.